### PR TITLE
Move demo build to its own job

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,10 @@
 name: Node CI
 
-on: [push, pull_request]
+on: # rebuild any PRs and main branch changes
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
         node-version: [8.x, 10.x, 12.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -23,16 +23,32 @@ jobs:
         yarn test
       env:
         CI: true
-    - name: check demo site builds
-      run: |
-        cd demo
-        yarn
-        yarn build-prod
-      env:
-        NODE_ENV: production
     - name: validate with elm-format
       run: |
         cd demo
         yarn
         yarn build
         yarn check-format
+
+  build-demo:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install module dependencies
+      run: yarn install --frozen-lockfile --production
+    - name: Check demo site builds
+      working-directory: demo
+      env:
+        NODE_ENV: production
+      run: |
+        yarn install --frozen-lockfile
+        yarn run build-prod

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "repository": "monty5811/postcss-elm-tailwind",
   "dependencies": {
-    "make-dir": "^3.0.2"
+    "make-dir": "^3.0.2",
+    "postcss": "^7.0.18"
   },
   "devDependencies": {
     "elm": "^0.19.1-2",
@@ -25,9 +26,6 @@
     "mocha": "^6.2.2",
     "postcss-cli": "^6.1.3",
     "tailwindcss": "^1.1.2"
-  },
-  "peerDependencies": {
-    "postcss": "^7.0.18"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
To make sure that the correct package dependencies are set we should run the demo build in its own job where we can install production dependencies for the package before running the demo project.

This also highlighted that `postcss` must be a dependency of the package.

Furthermore, It's unnecessary to run the checks on all pushes when they're run on pull_request too, so I've restricted the push checks to the master branch. This reduces noise and improves check speed, especially now we're doubling the number of jobs.